### PR TITLE
browser - guard against undefined timeout.unref

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ var ping = function(stream, opts, fn) {
 	};
 
 	id = setTimeout(loop, interval);
-	id.unref();
+	if (id.unref) id.unref();
 
 	eos(stream, unping);
 


### PR DESCRIPTION
`timeout.unref()` is node.js only : (
